### PR TITLE
Add support for Korthia items 

### DIFF
--- a/src/AdiBags_ByExpansion_Shadowlands/main.lua
+++ b/src/AdiBags_ByExpansion_Shadowlands/main.lua
@@ -28,6 +28,12 @@ options['Legendaries'] = {
     type = 'toggle',
     order = 92,
 }
+options['Korthia'] = {
+    name = "Korthia",
+    desc = 'Korthia Item',
+    type = 'toggle',
+    order = 93,
+}
 
 local module = {
     ["name"] = "shadowlands",
@@ -61,5 +67,6 @@ core:LoadCategories(AddonTable, module)
 core:AddCategoryItems(AddonTable.legendaries, "Legendaries", module)
 core:AddCategoryItems(AddonTable.conduits, "Conduits", module)
 core:AddCategoryItems(AddonTable.anima, "Anima", module)
+core:AddCategoryItems(AddonTable.korthia, "Korthia", module)
 
 core:LoadExpansion(module)

--- a/src/AdiBags_ByExpansion_Shadowlands/shadowlands.xml
+++ b/src/AdiBags_ByExpansion_Shadowlands/shadowlands.xml
@@ -44,6 +44,8 @@
     <Script file="dungeons\multiple.lua"/>
 
     <Script file="raids\castlenathria.lua"/>
+    
+    <Script file="zones\korthia.lua"/>
 
     <Script file="main.lua"/>
 

--- a/src/AdiBags_ByExpansion_Shadowlands/zones/korthia.lua
+++ b/src/AdiBags_ByExpansion_Shadowlands/zones/korthia.lua
@@ -1,0 +1,51 @@
+local AddonName, AddonTable = ...
+
+-- Korthia (Shadowlands)
+AddonTable.korthia = {
+    --rare mount handins
+    187153, --tasty-mushroom
+    187054, --lost-razorwing-egg
+    --1x relics
+    186685,
+    --8x relics
+    187322,
+    187457,
+    187324,
+    187323,
+    187460,
+    187458,
+    187459,
+    --48x relics
+    187465,
+    187327,
+    187463,
+    187325,
+    187326,
+    187462,
+    187478,
+    --100x relics
+    187336,
+    187466,
+    187332,
+    187328,
+    187334,
+    --150x relics
+    187330,
+    187329,
+    187467,
+    187331,
+    --300x relics
+    187311,
+    187333,
+    187350,
+    187335,
+    -- one time keys 
+    187612, --key-of-flowing-waters
+    187614, --key-of-many-thoughts
+    186984, --korthite-crystal-key
+    187613, --key-of-the-inner-chambers
+    -- items
+    187508, --trained-gromit-carrier
+    186718, --teleporter-repair-kit
+    186731, --repaired-riftkey
+}


### PR DESCRIPTION
Closes #20

This adds a new zone folder, and korthia page.
I took most of the item Ids directly from wowhead, doing a little web scraping.

Been using it locally for a bit and not had issues either, so believe its ready to share back. 