### PR TITLE
Remove non-existant reputation file from WarWithin

### DIFF
--- a/src/AdiBags_ByExpansion_WarWithin/ww.xml
+++ b/src/AdiBags_ByExpansion_WarWithin/ww.xml
@@ -4,7 +4,6 @@
     <Script file="categories\junk.lua" />
     <Script file="categories\loot.lua" />
     <Script file="categories\pets.lua" />
-    <Script file="categories\reputation.lua" />
     <Script file="categories\toys.lua" />
     <Script file="categories\trade.lua" />
     <Script file="categories\transmog.lua" />


### PR DESCRIPTION
When the War Within section was added, it included a reference to a `reputation.lua` file that doesn't exist. See #28

```
50x AdiBags_ByExpansion_WarWithin/categories/reputation.lua:1 Error loading AdiBags_ByExpansion_WarWithin/categories/reputation.lua
```